### PR TITLE
Relaxing dependencies locks in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-python-nvd3==0.13.10
-pandas==0.16.2
-pyyaml==3.11
+python-nvd3>=0.13.10
+pandas>=0.16.2
+pyyaml>=3.11


### PR DESCRIPTION
Those strong dependency locks are seemingly not needed here and create conflicts in pelican-plugins repository CI, during dependencies resolution.

Would you mind removing it please @romainx ?